### PR TITLE
Added Legal pages: "Privacy Policy, Licensing and Terms and Conditions"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
     "react-lazy-load": "^4.0.1",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "styled-components": "^6.1.11"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/Pages/Licensing.jsx
+++ b/src/Pages/Licensing.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import styled from 'styled-components';
+import BackBtn from "../components/BackBtn/BackBtn";
+
+
+const Licensing = () => {
+  return (
+
+    <>
+    <div className="py-8 mb-5 w-[50vw] justify-start ml-auto mr-auto mt-10">
+    <div>
+      <BackBtn Page={"Licensing"} />
+      <LicenseWrapper>
+    
+      <section>
+      <p>Last updated: May 17, 2024</p>
+        <p>Welcome to NactoCare. This Licensing Agreement governs your access and use of our software, content, and services. By accessing or using any part of our services, you agree to comply with and be bound by the terms outlined in this agreement.</p>
+      </section>
+      <section>
+        <h2>License Grant</h2>
+        <p>NactoCare hereby grants you a limited, non-exclusive, non-transferable, and revocable license to access and use our services strictly in accordance with the terms of this agreement. This license does not include any rights to:</p>
+        <ul>
+          <li>Modify, distribute, or create derivative works of our software or content;</li>
+          <li>Remove any proprietary notices or labels;</li>
+          <li>Use any data mining, robots, or similar data gathering or extraction methods;</li>
+          <li>Resell, sublicense, or publicly display any portion of our services;</li>
+          <li>Use our services for any purpose that is unlawful or prohibited by this agreement.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Restrictions on Use</h2>
+        <p>As a condition of your use of our services, you agree not to:</p>
+        <ul>
+          <li>Reproduce, duplicate, copy, sell, resell, or exploit any portion of the services without express written permission from NactoCare;</li>
+          <li>Use our services to transmit or post any unlawful, threatening, defamatory, obscene, or otherwise objectionable material;</li>
+          <li>Engage in any activity that interferes with or disrupts the services or the servers and networks that host our services;</li>
+          <li>Attempt to gain unauthorized access to any portion or feature of our services or any other systems or networks connected to our services;</li>
+          <li>Use our services to develop a competing platform or service.</li>
+        </ul>
+      </section>
+    
+      <section>
+        <h2>Changes to This Agreement</h2>
+        <p>NactoCare reserves the right to modify or update this Licensing Agreement at any time. We will notify you of any changes by posting the new agreement on this page. Your continued use of our services after any such changes constitutes your acceptance of the new terms.</p>
+      </section>
+      <section>
+        <h2>Contact Information</h2>
+        <p>If you have any questions or concerns about this Licensing Agreement, please contact us at: Email: nactoreorganization@gmail.com</p>
+      
+      </section>
+    </LicenseWrapper>
+    </div>
+  </div>
+    
+    </>
+  );
+};
+
+const LicenseWrapper = styled.div`
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  color: #333;
+  line-height: 1.6;
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    margin-top: 20px;
+  }
+
+  p {
+    margin: 10px 0;
+  }
+
+  ul {
+    list-style-type: disc;
+    margin-left: 20px;
+  }
+
+  li {
+    margin: 10px 0;
+  }
+
+  address {
+    font-style: normal;
+    line-height: 1.6;
+  }
+`;
+
+export default Licensing;

--- a/src/Pages/Licensing.jsx
+++ b/src/Pages/Licensing.jsx
@@ -11,45 +11,56 @@ const Licensing = () => {
     <div>
       <BackBtn Page={"Licensing"} />
       <LicenseWrapper>
-    
-      <section>
-      <p>Last updated: May 17, 2024</p>
-        <p>Welcome to NactoCare. This Licensing Agreement governs your access and use of our software, content, and services. By accessing or using any part of our services, you agree to comply with and be bound by the terms outlined in this agreement.</p>
-      </section>
-      <section>
-        <h2>License Grant</h2>
-        <p>NactoCare hereby grants you a limited, non-exclusive, non-transferable, and revocable license to access and use our services strictly in accordance with the terms of this agreement. This license does not include any rights to:</p>
-        <ul>
-          <li>Modify, distribute, or create derivative works of our software or content;</li>
-          <li>Remove any proprietary notices or labels;</li>
-          <li>Use any data mining, robots, or similar data gathering or extraction methods;</li>
-          <li>Resell, sublicense, or publicly display any portion of our services;</li>
-          <li>Use our services for any purpose that is unlawful or prohibited by this agreement.</li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>Restrictions on Use</h2>
-        <p>As a condition of your use of our services, you agree not to:</p>
-        <ul>
-          <li>Reproduce, duplicate, copy, sell, resell, or exploit any portion of the services without express written permission from NactoCare;</li>
-          <li>Use our services to transmit or post any unlawful, threatening, defamatory, obscene, or otherwise objectionable material;</li>
-          <li>Engage in any activity that interferes with or disrupts the services or the servers and networks that host our services;</li>
-          <li>Attempt to gain unauthorized access to any portion or feature of our services or any other systems or networks connected to our services;</li>
-          <li>Use our services to develop a competing platform or service.</li>
-        </ul>
-      </section>
-    
-      <section>
-        <h2>Changes to This Agreement</h2>
-        <p>NactoCare reserves the right to modify or update this Licensing Agreement at any time. We will notify you of any changes by posting the new agreement on this page. Your continued use of our services after any such changes constitutes your acceptance of the new terms.</p>
-      </section>
-      <section>
-        <h2>Contact Information</h2>
-        <p>If you have any questions or concerns about this Licensing Agreement, please contact us at: Email: nactoreorganization@gmail.com</p>
-      
-      </section>
-    </LicenseWrapper>
+            <section>
+              <p>Last updated: May 17, 2024</p>
+              <p>
+                Welcome to NactoCare. This Licensing Agreement governs your access and use of our software, content, and services. By accessing or using any part of our services, you agree to comply with and be bound by the terms outlined in this agreement.
+              </p>
+            </section>
+            <section>
+              <h2>GNU General Public License v3.0</h2>
+              <p>
+                This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+              </p>
+              <p>
+                This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+              </p>
+              <p>
+                You should have received a copy of the GNU General Public License along with this program. If not, see <a href="https://www.gnu.org/licenses/" target="_blank" rel="noopener noreferrer">https://www.gnu.org/licenses/</a>.
+              </p>
+            </section>
+            <section>
+              <h2>Permissions</h2>
+              <ul>
+                <li>Use: You are free to use the software for any purpose.</li>
+                <li>Study: You have the freedom to study how the program works and change it to make it do what you wish.</li>
+                <li>Distribute: You can redistribute copies of the original program so you can help others.</li>
+                <li>Modify: You can distribute copies of your modified versions to others.</li>
+              </ul>
+            </section>
+            <section>
+              <h2>Conditions</h2>
+              <ul>
+                <li>
+                  The source code must be made available when the software is distributed.
+                </li>
+                <li>
+                  Any modifications to the software must be licensed under the GNU GPL v3.0 or later.
+                </li>
+                <li>
+                  The license notice and copyright notice must be preserved in all copies or substantial portions of the software.
+                </li>
+              </ul>
+            </section>
+            <section>
+              <h2>Contact Information</h2>
+              <p>
+                If you have any questions or concerns about this Licensing Agreement, please contact us at:
+                  Email: <a href="mailto:nactoreorganization@gmail.com">nactoreorganization@gmail.com</a>
+              </p>
+            
+            </section>
+          </LicenseWrapper>
     </div>
   </div>
     

--- a/src/Pages/PrivacyPolicy.jsx
+++ b/src/Pages/PrivacyPolicy.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import styled from 'styled-components';
+import BackBtn from "../components/BackBtn/BackBtn";
+
+
+const PrivacyPolicy = () => {
+  return (
+   <>
+    <div className="py-8 mb-5 w-[50vw] justify-start ml-auto mr-auto mt-10">
+    <div>
+      <BackBtn Page={"Privacy Policy"} />
+      <PolicyWrapper>
+      
+      <section>
+      <p>Last updated: May 17, 2024</p>
+        <p>Welcome to NactoCare. We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy or our practices with regards to your personal information, please contact us at nactoreorganization@gmail.com</p>
+      </section>
+      <section>
+        <h2>Information We Collect</h2>
+        <p>We collect personal information that you provide to us, such as name, address, contact information, passwords and security data, and payment information. We collect personal information when you register for our services, express an interest in obtaining information about us or our products and services, participate in activities on the Services, or otherwise contact us.</p>
+      </section>
+      <section>
+        <h2>How We Use Your Information</h2>
+        <p>We use personal information collected via our Services for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations.</p>
+      </section>
+      <section>
+        <h2>Sharing Your Information</h2>
+        <p>We may process or share data based on the following legal basis:</p>
+        <ul>
+          <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information in a specific purpose.</li>
+          <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
+          <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
+          <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process, such as in response to a court order or a subpoena (including in response to public authorities to meet national security or law enforcement requirements).</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Security of Your Information</h2>
+        <p>We use administrative, technical, and physical security measures to help protect your personal information. While we have taken reasonable steps to secure the personal information you provide to us, please be aware that despite our efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse.</p>
+      </section>
+      <section>
+        <h2>Contact Us</h2>
+        <p>If you have questions or comments about this policy, you may email us at nactoreorganization@gmail.com.</p>
+      </section>
+    </PolicyWrapper>
+    </div>
+  </div>
+
+    </>
+  );
+};
+
+const PolicyWrapper = styled.div`
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  color: #333;
+  line-height: 1.6;
+  
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    margin-top: 20px;
+  }
+
+  p {
+    margin: 10px 0;
+  }
+
+  ul {
+    list-style-type: disc;
+    margin-left: 20px;
+  }
+
+  li {
+    margin: 10px 0;
+  }
+`;
+
+export default PrivacyPolicy;

--- a/src/Pages/PrivacyPolicy.jsx
+++ b/src/Pages/PrivacyPolicy.jsx
@@ -10,38 +10,37 @@ const PrivacyPolicy = () => {
     <div>
       <BackBtn Page={"Privacy Policy"} />
       <PolicyWrapper>
-      
-      <section>
-      <p>Last updated: May 17, 2024</p>
-        <p>Welcome to NactoCare. We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy or our practices with regards to your personal information, please contact us at nactoreorganization@gmail.com</p>
-      </section>
-      <section>
-        <h2>Information We Collect</h2>
-        <p>We collect personal information that you provide to us, such as name, address, contact information, passwords and security data, and payment information. We collect personal information when you register for our services, express an interest in obtaining information about us or our products and services, participate in activities on the Services, or otherwise contact us.</p>
-      </section>
-      <section>
-        <h2>How We Use Your Information</h2>
-        <p>We use personal information collected via our Services for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations.</p>
-      </section>
-      <section>
-        <h2>Sharing Your Information</h2>
-        <p>We may process or share data based on the following legal basis:</p>
-        <ul>
-          <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information in a specific purpose.</li>
-          <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
-          <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
-          <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process, such as in response to a court order or a subpoena (including in response to public authorities to meet national security or law enforcement requirements).</li>
-        </ul>
-      </section>
-      <section>
-        <h2>Security of Your Information</h2>
-        <p>We use administrative, technical, and physical security measures to help protect your personal information. While we have taken reasonable steps to secure the personal information you provide to us, please be aware that despite our efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse.</p>
-      </section>
-      <section>
-        <h2>Contact Us</h2>
-        <p>If you have questions or comments about this policy, you may email us at nactoreorganization@gmail.com.</p>
-      </section>
-    </PolicyWrapper>
+            <section>
+              <p>Last updated: May 17, 2024</p>
+              <p>Welcome to NactoCare. We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy or our practices with regards to your personal information, please contact us at nactoreorganization@gmail.com.</p>
+            </section>
+            <section>
+              <h2>Information We Collect</h2>
+              <p>We collect personal information that you provide to us, such as name, address, contact information, and payment information. We collect personal information when you register for our services, express an interest in obtaining information about us or our products and services, participate in activities on the Services, or otherwise contact us.</p>
+            </section>
+            <section>
+              <h2>How We Use Your Information</h2>
+              <p>We use personal information collected via our Services for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations.</p>
+            </section>
+            <section>
+              <h2>Sharing Your Information</h2>
+              <p>We may process or share data based on the following legal basis:</p>
+              <ul>
+                <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information for a specific purpose.</li>
+                <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
+                <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
+                <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process, such as in response to a court order or a subpoena (including in response to public authorities to meet national security or law enforcement requirements).</li>
+              </ul>
+            </section>
+            <section>
+              <h2>Security of Your Information</h2>
+              <p>We use administrative, technical, and physical security measures to help protect your personal information. While we have taken reasonable steps to secure the personal information you provide to us, please be aware that despite our efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse.</p>
+            </section>
+            <section>
+              <h2>Contact Us</h2>
+              <p>If you have questions or comments about this policy, you may email us at: <a href="mailto:nactoreorganization@gmail.com">nactoreorganization@gmail.com</a>.</p>
+            </section>
+          </PolicyWrapper>
     </div>
   </div>
 

--- a/src/Pages/TermsAndConditions.jsx
+++ b/src/Pages/TermsAndConditions.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import styled from 'styled-components';
+import BackBtn from "../components/BackBtn/BackBtn";
+
+
+const TermsAndConditions = () => {
+  return (
+    <>
+        <div className="py-8 mb-5 w-[50vw] justify-start ml-auto mr-auto mt-10">
+    <div>
+      <BackBtn Page={"Terms And Conditions"} />
+      <TermsWrapper>
+      <section>
+      <p>Last updated: May 17, 2024</p>
+        <p>Welcome to NactoCare. These terms and conditions outline the rules and regulations for the use of NactoCare's website and services. By accessing this website, we assume you accept these terms and conditions. Do not continue to use NactoCare if you do not agree to all of the terms and conditions stated on this page.</p>
+      </section>
+      <section>
+        <h2>Eligibility</h2>
+        <p>By using our services, you represent and warrant that you are at least 18 years old and have the legal capacity to enter into these terms. If you are using our services on behalf of an organization, you represent and warrant that you have the authority to bind the organization to these terms.</p>
+      </section>
+      <section>
+        <h2>Intellectual Property</h2>
+        <p>Unless otherwise stated, NactoCare and/or its licensors own the intellectual property rights for all material on NactoCare. All intellectual property rights are reserved. You may access this from NactoCare for your own personal use subjected to restrictions set in these terms and conditions.</p>
+        <p>You must not:</p>
+        <ul>
+          <li>Republish material from NactoCare</li>
+          <li>Sell, rent, or sub-license material from NactoCare</li>
+          <li>Reproduce, duplicate, or copy material from NactoCare</li>
+          <li>Redistribute content from NactoCare</li>
+        </ul>
+      </section>
+      <section>
+        <h2>User Accounts</h2>
+        <p>When you create an account with us, you must provide us with accurate and complete information. You are responsible for maintaining the confidentiality of your account and password and for restricting access to your computer. You agree to accept responsibility for all activities that occur under your account or password.</p>
+      </section>
+      <section>
+        <h2>Prohibited Activities</h2>
+        <p>You may not access or use the site for any purpose other than that for which we make the site and our services available. The site may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us. Prohibited activities include, but are not limited to:</p>
+        <ul>
+          <li>Systematically retrieving data or other content from the site to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.</li>
+          <li>Making any unauthorized use of the site, including collecting usernames and/or email addresses of users by electronic or other means for the purpose of sending unsolicited email, or creating user accounts by automated means or under false pretenses.</li>
+          <li>Engaging in unauthorized framing of or linking to the site.</li>
+          <li>Tricking, defrauding, or misleading us and other users, especially in any attempt to learn sensitive account information such as user passwords.</li>
+          <li>Engaging in any automated use of the system, such as using scripts to send comments or messages, or using any data mining, robots, or similar data gathering and extraction tools.</li>
+          <li>Using the site to advertise or offer to sell goods and services.</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Limitation of Liability</h2>
+        <p>In no event shall NactoCare, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential, or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from (i) your access to or use of or inability to access or use the service; (ii) any conduct or content of any third party on the service; (iii) any content obtained from the service; and (iv) unauthorized access, use, or alteration of your transmissions or content, whether based on warranty, contract, tort (including negligence), or any other legal theory, whether or not we have been informed of the possibility of such damage.</p>
+      </section>
+      <section>
+        <h2>Governing Law</h2>
+        <p>These terms shall be governed and construed in accordance with the laws of India, without regard to its conflict of law provisions. Our failure to enforce any right or provision of these terms will not be considered a waiver of those rights. If any provision of these terms is held to be invalid or unenforceable by a court, the remaining provisions of these terms will remain in effect. These terms constitute the entire agreement between us regarding our service, and supersede and replace any prior agreements we might have had between us regarding the service.</p>
+      </section>
+      <section>
+        <h2>Termination</h2>
+        <p>We may terminate or suspend your account and bar access to the service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of the terms.</p>
+        <p>If you wish to terminate your account, you may simply discontinue using the service.</p>
+      </section>
+      <section>
+        <h2>Changes to These Terms</h2>
+        <p>We reserve the right, at our sole discretion, to modify or replace these terms at any time. If a revision is material, we will provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion. By continuing to access or use our service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use the service.</p>
+      </section>
+      <section>
+        <h2>Contact Us</h2>
+        <p>If you have any questions about these terms, 
+            <br />please contact us at: Email: nactoreorganization@gmail.com</p>
+
+      </section>
+    </TermsWrapper>
+    </div>
+  </div>
+    </>
+  );
+};
+
+const TermsWrapper = styled.div`
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  color: #333;
+  line-height: 1.6;
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    margin-top: 20px;
+  }
+
+  p {
+    margin: 10px 0;
+  }
+
+  ul {
+    list-style-type: disc;
+    margin-left: 20px;
+  }
+
+  li {
+    margin: 10px 0;
+  }
+
+  address {
+    font-style: normal;
+    line-height: 1.6;
+  }
+`;
+
+export default TermsAndConditions;

--- a/src/Pages/TermsAndConditions.jsx
+++ b/src/Pages/TermsAndConditions.jsx
@@ -48,7 +48,7 @@ const TermsAndConditions = () => {
       
       <section>
         <h2>Limitation of Liability</h2>
-        <p>In no event shall NactoCare, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential, or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from (i) your access to or use of or inability to access or use the service; (ii) any conduct or content of any third party on the service; (iii) any content obtained from the service; and (iv) unauthorized access, use, or alteration of your transmissions or content, whether based on warranty, contract, tort (including negligence), or any other legal theory, whether or not we have been informed of the possibility of such damage.</p>
+        <p>In no event shall Nactore, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential, or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from (i) your access to or use of or inability to access or use the service; (ii) any conduct or content of any third party on the service; (iii) any content obtained from the service; and (iv) unauthorized access, use, or alteration of your transmissions or content, whether based on warranty, contract, tort (including negligence), or any other legal theory, whether or not we have been informed of the possibility of such damage.</p>
       </section>
       <section>
         <h2>Governing Law</h2>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -63,17 +63,17 @@ function Footer() {
                 </h2>
                 <ul className="text-gray-500  font-medium">
                   <li className="mb-4">
-                    <a href="#" className="hover:underline">
+                    <a href="/privacypolicy" className="hover:underline">
                       Privacy Policy
                     </a>
                   </li>
                   <li className="mb-4">
-                    <a href="#" className="hover:underline">
+                    <a href="/licensing" className="hover:underline">
                       Licensing
                     </a>
                   </li>
                   <li className="mb-4">
-                    <a href="#" className="hover:underline">
+                    <a href="/termsandconditions" className="hover:underline">
                       Terms &amp; Conditions
                     </a>
                   </li>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -17,6 +17,9 @@ import AboutPage from "./Pages/AboutPage.jsx";
 import BlogPage from "./Pages/BlogPage.jsx";
 import Booking from "./Pages/Booking.jsx";
 import Blogs from "./Pages/Blogs.jsx";
+import PrivacyPolicy from "./Pages/PrivacyPolicy.jsx";
+import Licensing from "./Pages/Licensing.jsx";
+import TermsAndConditions from "./Pages/TermsAndConditions.jsx";
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -30,6 +33,9 @@ const router = createBrowserRouter(
       <Route path="blog" element={<BlogPage />} />
       <Route path="blog/:slug" element={<Blogs />} />
       <Route path="/book-nurse" element={<Booking />} />
+      <Route path="/privacypolicy" element={<PrivacyPolicy />} />
+      <Route path="/licensing" element={<Licensing />} />
+      <Route path="/termsandconditions" element={<TermsAndConditions />} />
     </Route>
   )
 );


### PR DESCRIPTION
Fixed issue #56 

I've added the legal pages: **"Privacy Policy"**, **"Licensing"** and **"Terms and Conditions"**, ensuring the **design theme** of the website. Additionally, I've also added the links of the respective pages in the footer.

### Privacy Policy
![image](https://github.com/Nactore-Org/Nacto-Care/assets/101971980/b377500a-858b-420d-8e92-4c1ae3fdb2a0)

### Licencing
![image](https://github.com/Nactore-Org/Nacto-Care/assets/101971980/b81cc3f6-b799-49f5-9fb2-0b56bafab3b5)

### Terms and Conditions
![image](https://github.com/Nactore-Org/Nacto-Care/assets/101971980/d56bab6d-2f2d-4fb6-8316-d50420e5a170)

Please take a look at it and review it.
