### PR TITLE
Resolved the Vercel 404 "Page Not Found" Error

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -14,12 +14,12 @@ function Footer() {
                 </h2>
                 <ul className="text-gray-500  font-medium">
                   <li className="mb-4">
-                    <a href="#" className=" hover:underline">
+                    <a href="/about" className=" hover:underline">
                       About
                     </a>
                   </li>
                   <li className="mb-4">
-                    <a href="#" className="hover:underline">
+                    <a href="/careers" className="hover:underline">
                       Careers
                     </a>
                   </li>
@@ -29,7 +29,7 @@ function Footer() {
                     </a>
                   </li>
                   <li className="mb-4">
-                    <a href="#" className="hover:underline">
+                    <a href="/blog" className="hover:underline">
                       Blog
                     </a>
                   </li>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -33,9 +33,9 @@ const router = createBrowserRouter(
       <Route path="blog" element={<BlogPage />} />
       <Route path="blog/:slug" element={<Blogs />} />
       <Route path="/book-nurse" element={<Booking />} />
-      <Route path="/privacypolicy" element={<PrivacyPolicy />} />
-      <Route path="/licensing" element={<Licensing />} />
-      <Route path="/termsandconditions" element={<TermsAndConditions />} />
+      <Route path="privacypolicy" element={<PrivacyPolicy />} />
+      <Route path="licensing" element={<Licensing />} />
+      <Route path="termsandconditions" element={<TermsAndConditions />} />
     </Route>
   )
 );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+        {"source": "/(.*)", "destination": "/"}
+    ]
+}


### PR DESCRIPTION
##  Issue
This pull request addresses, Issue #87 

## Description
To rectify the {404 Not Found Error}, it is necessary to establish redirect and rewrite rules for the React Router application. These rules will assist the application in circumventing the "Page Not Found" error.

That's why I created a `vercel.json` file in the root directory of the project. This file will enable Vercel to configure the routing accurately.

## Type of PR

- [X] Bug fix


## Screenshots / videos 
**Changes 1:**
- I have linked and updated the navigations in the footer for all pages 

![image](https://github.com/Nactore-Org/Nacto-Care/assets/101971980/77f1d56f-e65c-446e-9492-e7da61477f2b)

**Changes 2:** 
- Added `vercel.json` : This image represents the structure of the `vercel.json` file and the code snippet.

![image](https://github.com/Nactore-Org/Nacto-Care/assets/101971980/50f2135a-b26a-444f-b341-d56fc3bcb813)

- The provided **code snippet** instructs Vercel to rewrite any incoming URL path to the root path. 
- This configuration ensures that when we initiate a redirect with a child path, Vercel will redirect it to the root path, effectively preventing the occurrence of the 404 Not Found Error.
- 
## Additional context for Reviewers:
- The changes are working or not will know only after the vercel deployment (As I believe it might not show any error in the preview or local host)
- Please ensure that in **"vercel deployment dashboard"** you picked **vitejs** as a framework (if applicable)


@Harshil-Jani  Take a look at this and inform me if it does not work. so that I can look for an additional alternate solution, Thank you.
