### PR TITLE
fixed same background color for both modes in Signup page  #100

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,12 @@ body.dark .login , .signup {
   color: white
 }
 
+/* Add light mode styles for signup */
+body.light .signup {
+  background-color: white;
+  color: black;
+}
+
 body.dark .contact-para {
   color: white;
 }


### PR DESCRIPTION
## Related Issue
This PR fixes the issue #100 

## Description

Here issue is that the background color of Signup page are stay same as dark color for both modes (light & Dark), even after clicking on the change color mode button.

I have resolved this issue by  adding style for the light mode for signup page in the `index.css` file .

## Type of PR

- [ X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)


Screenshot with issue -

![332558619-e02134c2-78ec-48ad-8ebd-f02502965ff7](https://github.com/Nactore-Org/Nacto-Care/assets/115466381/f464924f-a343-4658-974a-0b0ef56b6c67)

Screenshot with resolved issue -
![image](https://github.com/Nactore-Org/Nacto-Care/assets/115466381/58b07d44-0c47-4701-b77f-1ee73330c13c)


## Checklist:
- [X ] I have performed a self-review of my code
- [ X] I have read and followed the Contribution Guidelines.
- [X ] I have tested the changes thoroughly before submitting this pull request.
- [ X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
The issue arise due the missing style for light mode for signup page.
