### PR TITLE
Fix 🐞: Persist Theme Preference Across Page Reloads

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -43,10 +43,17 @@ const router = createBrowserRouter(
 export const ThemeContext = createContext(null);
 
 const App = () => {
-  const [theme, setTheme] = useState("light");
+  const [theme, setTheme] = useState(() => {
+    const storedTheme = localStorage.getItem("theme");
+    return storedTheme || "light";
+  });
 
   const toggleTheme = () => {
-    setTheme((curr) => (curr === "light" ? "dark" : "light"));
+    setTheme((curr) => {
+      const newTheme = curr === "light" ? "dark" : "light";
+      localStorage.setItem("theme", newTheme);
+      return newTheme;
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Related Issue
This PR addresses the issue #107 

## Description
I have solved the issue where the selected theme (light/dark mode) gets reset upon refreshing the page. 

The theme preference is now stored in the browser's local storage, ensuring that the user's theme choice persists across page reloads and navigations 

## Type of PR

- [X] Bug fix

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.

I hope it works... @Harshil-Jani  please take a look and review it, Thank you.
Do let me know if it doesn't work out.

## Edit:
I have checked on my local server the dark mode theme remained enabled even after refreshing the page and Even when I navigated away from the page and came back later the theme persisted. This modification will surely impress and increase the user experience with the website. **Thank you for the opportunity.**
