### PR TITLE
Optimised the FAQ page for dark theme

### DIFF
--- a/src/styles/Faq.css
+++ b/src/styles/Faq.css
@@ -1,39 +1,44 @@
+.main-heading {
+  display: flex;
+  margin-top: 30px;
+  padding: 20px;
+  background: #f1f4ff;
+  border-radius: 5px;
+  box-shadow: rgba(0, 0, 0, 0.16) 0 1px 4px;
+  cursor: pointer;
+  color: #303243; /* Add this line to set the text color to the default color */
+}
 
-  
-  .main-heading {
-    display: flex;
-    margin-top: 30px;
-    padding: 20px;
-    background: #f1f4ff;
-    border-radius: 5px;
-    box-shadow: rgba(0, 0, 0, 0.16) 0 1px 4px;
-    cursor: pointer;
-  }
-  
-  .main-heading h3 {
-    margin-left: 30px;
-    color: #303243;
-    word-spacing: 1px;
-    letter-spacing: 1px;
-    font-weight: 600;
-    font-size: 18px;
-  }
-  .main-heading p {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+.main-heading h3 {
+  margin-left: 30px;
+  word-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: 600;
+  font-size: 18px;
+}
 
-  .answers {
-    padding: 30px 20px 40px 20px;
-    font-size: 16px;
-    font-weight: 500;
-    background: #dde4ff;
-    color: rgb(40, 37, 53);
-    border-radius: 0 0 5px 5px;
-  }
+.main-heading p {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
-  body.dark .answers {
-    color: rgb(40, 37, 53);
-  }
+.answers {
+  padding: 30px 20px 40px 20px;
+  font-size: 16px;
+  font-weight: 500;
+  background: #dde4ff;
+  color: rgb(40, 37, 53);
+  border-radius: 0 0 5px 5px;
+}
+
+body.dark .answers {
+  background-color: #222222;
+  color: white;
+}
+
+body.dark .main-heading {
+  background-color: #333333;
+  color: white;
+}


### PR DESCRIPTION
## Related Issue
Issue #203 

## Description
1. Changed the background color of the FAQ cards to gray in dark theme.
2. Changed the background color of the main heading to gray and the text color to white in dark theme.
3. Changed the background color of the answers to a darker gray.
4. Changed the text color of the answers to white.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/Nactore-Org/Nacto-Care/assets/127531721/228b65cb-4a0f-4fb2-a6e1-5204d0cee536)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
please review my PR and provide feedback. I'll be happy to work on any required changes.
